### PR TITLE
update so that allComponentsComplete no longer uses PLP to determine …

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "name": "adapt-pageIncompletePrompt",
     "repository": "git://github.com/cgkineo/adapt-pageIncompletePrompt",
     "framework": "^2.0.0",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "homepage": "https://github.com/cgkineo/adapt-pageIncompletePrompt",
     "issues": "https://github.com/cgkineo/adapt-pageIncompletePrompt/issues/",
     "displayName": "Page Incomplete Prompt",


### PR DESCRIPTION
…if it should be checking to see if a component needs to be completed or not (fixes #8).

Also implement some changes to make PIP compatible with the new version of Notify (n.b. this is pending a further update to the framework to add in a notify:cancelled event)