### PR TITLE
New: Migration scripts added to repo (fixes #46)

### DIFF
--- a/migrations/v2.js
+++ b/migrations/v2.js
@@ -1,4 +1,4 @@
-import { describe, whereFromPlugin, mutateContent, checkContent, updatePlugin, getCourse } from 'adapt-migrations';
+import { describe, whereFromPlugin, mutateContent, checkContent, updatePlugin, getCourse, testStopWhere, testSuccessWhere } from 'adapt-migrations';
 
 describe('Page Incomplete Prompt - v2.0.8 to v2.1.0', async () => {
   let course, coursePIP;
@@ -14,4 +14,25 @@ describe('Page Incomplete Prompt - v2.0.8 to v2.1.0', async () => {
     return true;
   });
   updatePlugin('Page Incomplete Prompt - update to v2.1.0', { name: 'adapt-pageIncompletePrompt', version: '2.1.0', framework: '>=3.3' });
+
+  testSuccessWhere('page incomplete prompt with empty course', {
+    fromPlugins: [{ name: 'adapt-pageIncompletePrompt', version: '2.0.8' }],
+    content: [
+      { _id: 'c-100', _component: 'mcq', _pageIncompletePrompt: {} },
+      { _id: 'c-105', _component: 'mcq' },
+      { _type: 'course' }
+    ]
+  });
+
+  testSuccessWhere('page incomplete prompt with empty course globals', {
+    fromPlugins: [{ name: 'adapt-pageIncompletePrompt', version: '2.0.8' }],
+    content: [
+      { _id: 'c-100', _component: 'mcq', _pageIncompletePrompt: {} },
+      { _type: 'course', _pageIncompletePrompt: {}, _globals: { _extensions: { _pageIncompletePrompt: {} } } }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-pageIncompletePrompt', version: '2.1.0' }]
+  });
 });

--- a/migrations/v2.js
+++ b/migrations/v2.js
@@ -1,0 +1,26 @@
+import { describe, whereFromPlugin, mutateContent, checkContent, updatePlugin, getCourse } from 'adapt-migrations';
+import _ from 'lodash';
+
+describe('Page Incomplete Prompt - v2.0.2 to v2.0.3', async () => {
+  let course, coursePIPGlobals;
+  whereFromPlugin('Page Incomplete Prompt - from v2.0.2', { name: 'adapt-pageIncompletePrompt', version: '<2.0.3' });
+  // mutateContent('Page Incomplete Prompt - add globals if missing', async (content) => {
+  //   course = getCourse();
+  //   if (!_.has(course, '_globals._extensions._pageIncompletePrompt')) _.set(course, '_globals._extensions._pageIncompletePrompt', {});
+  //   coursePIPGlobals = course._globals._extensions._pageIncompletePrompt;
+  //   return true;
+  // });
+  // mutateContent('Page Incomplete Prompt - add globals _navOrder', async (content) => {
+  //   _.set(coursePIPGlobals, '_navOrder', 1);
+  //   return true;
+  // });
+  // checkContent('Page Incomplete Prompt - check globals _navOrder attribute', async content => {
+  //   if (coursePIPGlobals === undefined) throw new Error('Page Incomplete Prompt - globals _pageIncompletePrompt invalid');
+  //   return true;
+  // });
+  // checkContent('Page Incomplete Prompt - check globals _navOrder attribute', async content => {
+  //   if (coursePIPGlobals._navOrder !== 1) throw new Error('Page Incomplete Prompt - globals _navOrder invalid');
+  //   return true;
+  // });
+  updatePlugin('Page Incomplete Prompt - update to v2.0.3', { name: 'adapt-pageIncompletePrompt', version: '2.0.3', framework: '^2.0.0' });
+});

--- a/migrations/v2.js
+++ b/migrations/v2.js
@@ -1,16 +1,28 @@
-import { describe, whereFromPlugin, mutateContent, checkContent, updatePlugin, getCourse, testStopWhere, testSuccessWhere } from 'adapt-migrations';
+import { describe, whereFromPlugin, whereContent, mutateContent, checkContent, updatePlugin, getCourse, testStopWhere, testSuccessWhere } from 'adapt-migrations';
+import _ from 'lodash';
 
 describe('Page Incomplete Prompt - v2.0.8 to v2.1.0', async () => {
   let course, coursePIP;
   whereFromPlugin('Page Incomplete Prompt - from v2.0.8', { name: 'adapt-pageIncompletePrompt', version: '<2.1.0' });
+  whereContent('Page Incomplete Prompt - has course object', async content => {
+    return content.some(item => item._type === 'course');
+  });
   mutateContent('Page Incomplete Prompt - add course _pageIncompletePrompt._classes', async (content) => {
     course = getCourse();
-    coursePIP = course._pageIncompletePrompt;
-    coursePIP._classes = '';
+    coursePIP = _.get(course, '_pageIncompletePrompt');
+
+    if (!coursePIP) {
+      coursePIP = {};
+      _.set(course, '_pageIncompletePrompt', coursePIP);
+    }
+
+    if (!_.has(coursePIP, '_classes')) coursePIP._classes = '';
+
     return true;
   });
-  checkContent('Page Incomplete Prompt - check course _pageIncompletePrompt._isHidden', async content => {
-    if (coursePIP._classes === undefined) throw new Error('Page Incomplete Prompt - course _pageIncompletePrompt._classes invalid');
+  checkContent('Page Incomplete Prompt - check course _pageIncompletePrompt._classes', async content => {
+    if (!_.has(course, '_pageIncompletePrompt')) throw new Error('Page Incomplete Prompt - course _pageIncompletePrompt missing');
+    if (!_.has(coursePIP, '_classes')) throw new Error('Page Incomplete Prompt - course _pageIncompletePrompt._classes invalid');
     return true;
   });
   updatePlugin('Page Incomplete Prompt - update to v2.1.0', { name: 'adapt-pageIncompletePrompt', version: '2.1.0', framework: '>=3.3' });
@@ -18,12 +30,27 @@ describe('Page Incomplete Prompt - v2.0.8 to v2.1.0', async () => {
   testSuccessWhere('page incomplete prompt with empty course setting', {
     fromPlugins: [{ name: 'adapt-pageIncompletePrompt', version: '2.0.8' }],
     content: [
-      { _id: 'c-100', _component: 'mcq' },
+      { _id: 'c-100', _component: 'text' },
       { _type: 'course', _pageIncompletePrompt: {} }
     ]
   });
 
   testStopWhere('incorrect version', {
     fromPlugins: [{ name: 'adapt-pageIncompletePrompt', version: '2.1.0' }]
+  });
+
+  testStopWhere('missing course object', {
+    fromPlugins: [{ name: 'adapt-pageIncompletePrompt', version: '2.0.8' }],
+    content: [
+      { _id: 'c-100', _component: 'text' }
+    ]
+  });
+
+  testSuccessWhere('page incomplete prompt creates course settings', {
+    fromPlugins: [{ name: 'adapt-pageIncompletePrompt', version: '2.0.8' }],
+    content: [
+      { _id: 'c-100', _component: 'text' },
+      { _type: 'course' }
+    ]
   });
 });

--- a/migrations/v2.js
+++ b/migrations/v2.js
@@ -1,26 +1,23 @@
 import { describe, whereFromPlugin, mutateContent, checkContent, updatePlugin, getCourse } from 'adapt-migrations';
 import _ from 'lodash';
 
-describe('Page Incomplete Prompt - v2.0.2 to v2.0.3', async () => {
-  let course, coursePIPGlobals;
-  whereFromPlugin('Page Incomplete Prompt - from v2.0.2', { name: 'adapt-pageIncompletePrompt', version: '<2.0.3' });
-  // mutateContent('Page Incomplete Prompt - add globals if missing', async (content) => {
-  //   course = getCourse();
-  //   if (!_.has(course, '_globals._extensions._pageIncompletePrompt')) _.set(course, '_globals._extensions._pageIncompletePrompt', {});
-  //   coursePIPGlobals = course._globals._extensions._pageIncompletePrompt;
-  //   return true;
-  // });
-  // mutateContent('Page Incomplete Prompt - add globals _navOrder', async (content) => {
-  //   _.set(coursePIPGlobals, '_navOrder', 1);
-  //   return true;
-  // });
-  // checkContent('Page Incomplete Prompt - check globals _navOrder attribute', async content => {
-  //   if (coursePIPGlobals === undefined) throw new Error('Page Incomplete Prompt - globals _pageIncompletePrompt invalid');
-  //   return true;
-  // });
-  // checkContent('Page Incomplete Prompt - check globals _navOrder attribute', async content => {
-  //   if (coursePIPGlobals._navOrder !== 1) throw new Error('Page Incomplete Prompt - globals _navOrder invalid');
-  //   return true;
-  // });
-  updatePlugin('Page Incomplete Prompt - update to v2.0.3', { name: 'adapt-pageIncompletePrompt', version: '2.0.3', framework: '^2.0.0' });
+describe('Page Incomplete Prompt - v2.0.8 to v2.1.0', async () => {
+  let course, coursePIP;
+  whereFromPlugin('Page Incomplete Prompt - from v2.0.8', { name: 'adapt-pageIncompletePrompt', version: '<2.1.0' });
+  mutateContent('Page Incomplete Prompt - add course _pageIncompletePrompt._classes', async (content) => {
+    course = getCourse();
+    if (!_.has(course, '_pageIncompletePrompt')) _.set(course, '_pageIncompletePrompt', {});
+    coursePIP = course._pageIncompletePrompt;
+    coursePIP._classes = '';
+    return true;
+  });
+  checkContent('Page Incomplete Prompt - check course _pageIncompletePrompt object', async content => {
+    if (coursePIP === undefined) throw new Error('Page Incomplete Prompt - course _pageIncompletePrompt invalid');
+    return true;
+  });
+  checkContent('Page Incomplete Prompt - check course _pageIncompletePrompt._isHidden', async content => {
+    if (coursePIP._classes === undefined) throw new Error('Page Incomplete Prompt - course _pageIncompletePrompt._classes invalid');
+    return true;
+  });
+  updatePlugin('Page Incomplete Prompt - update to v2.1.0', { name: 'adapt-pageIncompletePrompt', version: '2.1.0', framework: '>=3.3' });
 });

--- a/migrations/v2.js
+++ b/migrations/v2.js
@@ -15,20 +15,11 @@ describe('Page Incomplete Prompt - v2.0.8 to v2.1.0', async () => {
   });
   updatePlugin('Page Incomplete Prompt - update to v2.1.0', { name: 'adapt-pageIncompletePrompt', version: '2.1.0', framework: '>=3.3' });
 
-  testSuccessWhere('page incomplete prompt with empty course', {
+  testSuccessWhere('page incomplete prompt with empty course setting', {
     fromPlugins: [{ name: 'adapt-pageIncompletePrompt', version: '2.0.8' }],
     content: [
-      { _id: 'c-100', _component: 'mcq', _pageIncompletePrompt: {} },
-      { _id: 'c-105', _component: 'mcq' },
-      { _type: 'course' }
-    ]
-  });
-
-  testSuccessWhere('page incomplete prompt with empty course globals', {
-    fromPlugins: [{ name: 'adapt-pageIncompletePrompt', version: '2.0.8' }],
-    content: [
-      { _id: 'c-100', _component: 'mcq', _pageIncompletePrompt: {} },
-      { _type: 'course', _pageIncompletePrompt: {}, _globals: { _extensions: { _pageIncompletePrompt: {} } } }
+      { _id: 'c-100', _component: 'mcq' },
+      { _type: 'course', _pageIncompletePrompt: {} }
     ]
   });
 

--- a/migrations/v2.js
+++ b/migrations/v2.js
@@ -1,18 +1,12 @@
 import { describe, whereFromPlugin, mutateContent, checkContent, updatePlugin, getCourse } from 'adapt-migrations';
-import _ from 'lodash';
 
 describe('Page Incomplete Prompt - v2.0.8 to v2.1.0', async () => {
   let course, coursePIP;
   whereFromPlugin('Page Incomplete Prompt - from v2.0.8', { name: 'adapt-pageIncompletePrompt', version: '<2.1.0' });
   mutateContent('Page Incomplete Prompt - add course _pageIncompletePrompt._classes', async (content) => {
     course = getCourse();
-    if (!_.has(course, '_pageIncompletePrompt')) _.set(course, '_pageIncompletePrompt', {});
     coursePIP = course._pageIncompletePrompt;
     coursePIP._classes = '';
-    return true;
-  });
-  checkContent('Page Incomplete Prompt - check course _pageIncompletePrompt object', async content => {
-    if (coursePIP === undefined) throw new Error('Page Incomplete Prompt - course _pageIncompletePrompt invalid');
     return true;
   });
   checkContent('Page Incomplete Prompt - check course _pageIncompletePrompt._isHidden', async content => {


### PR DESCRIPTION
Fix #46 

Part of https://github.com/cgkineo/cgkineo/issues/3

### New
- Migration scripts added to repo

### Migration milestones
#### [2.0.3](https://github.com/cgkineo/adapt-pageIncompletePrompt/releases/tag/v2.0.3)
- Made AAT compatible. Slight chance that if a client was using this plugin before the object name was [fixed](https://github.com/cgkineo/adapt-pageIncompletePrompt/commit/78d5e65f46603848c9cc281379c37e2b75ddcb8c), it will be missing the proper configuration. The fix was made on the same tag, though.

#### [2.1.0](https://github.com/cgkineo/adapt-pageIncompletePrompt/commit/24cf5f4f6055d7d6eddd93d8bedab0622993ddd7#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88)
- Add `_classes`